### PR TITLE
Fix f-string quote conflict and backslash escape for Python <3.12; Add None check for importlib.util.find_spec origin to avoid type errors

### DIFF
--- a/pylings/config.py
+++ b/pylings/config.py
@@ -161,7 +161,8 @@ class ConfigManager:
                 if exercise_name == ce_name:
                     hint = data.get("hint", "")
                     log.debug("Hint found: %s", {hint})
-                    return f"{HINT_TITLE}\n\n{hint.replace("[", "\\[")}"
+                    escaped_hint = hint.replace('[', '\\[')
+                    return f"{HINT_TITLE}\n\n{escaped_hint}"
 
         log.debug("No hint for: %s", {ce_name})
         return NO_HINT_MESSAGE

--- a/pylings/utils.py
+++ b/pylings/utils.py
@@ -253,7 +253,11 @@ class PylingsUtils:
         Returns:
             Path: Path to the root of the installed package.
         """
-        return Path(importlib.util.find_spec("pylings").origin).parent
+        spec = importlib.util.find_spec("pylings")
+        if spec is None or spec.origin is None:
+            # Handle the error or provide a fallback path
+            raise ImportError("Cannot find 'pylings' module or origin path")
+        return Path(spec.origin).parent
 
     @staticmethod
     def get_workspace_version() -> Optional[str]:
@@ -337,7 +341,8 @@ class PylingsUtils:
             Text: Rich text object with embedded link.
         """
         uri = target_path.absolute().as_uri()
-        formatted = f"{prefix}/{display.replace('\\', '/')}"
+        fixed_display = display.replace('\\', '/')
+        formatted = f"{prefix}/{fixed_display}"
         text = Text(label)
         text.append(f"{GREEN}{formatted}{RESET_COLOR}", style=f" link {uri}")
         return text


### PR DESCRIPTION
### Before Fix (Python <3.12)

```bash
(Pylings) youssef-adly@LOQ-15ARP9:~/repos/Pylings$ python3 -V
Python 3.10.17

(Pylings) youssef-adly@LOQ-15ARP9:~/repos/Pylings$ pylings
Traceback (most recent call last):
  File "/home/youssef-adly/repos/Pylings/.venv/bin/pylings", line 4, in <module>
    from pylings.__main__ import main
  File "/home/youssef-adly/repos/Pylings/pylings/__main__.py", line 11, in <module>
    from pylings.pylings import main
  File "/home/youssef-adly/repos/Pylings/pylings/pylings.py", line 15, in <module>
    from pylings.exercises import ExerciseManager
  File "/home/youssef-adly/repos/Pylings/pylings/exercises.py", line 15, in <module>
    from pylings.config import ConfigManager
  File "/home/youssef-adly/repos/Pylings/pylings/config.py", line 164
    return f"{HINT_TITLE}\n\n{hint.replace("[", "\\[")}"
                                            ^
SyntaxError: f-string: unmatched '('
```

**Reason:**  
Python <3.12 does not support unescaped quotes or brackets inside f-strings — this caused a `SyntaxError` when using `hint.replace("[", "\\[")` inside the f-string directly.

### After Fix

```bash
(Pylings) youssef-adly@LOQ-15ARP9:~/repos/Pylings$ pylings
Not a pylings workspace.
Change to pylings workspace, if it exists, or
Run: pylings init [--path /path/to/pylings]
         Or pylings --help
```
