### PR TITLE
feat(theme): add dynamic theme support and theming config

### DIFF
--- a/pylings/config/themes.toml
+++ b/pylings/config/themes.toml
@@ -1,0 +1,80 @@
+[default]
+GREEN = "bold green"
+RED = "bold red"
+ORANGE = "bold orange"
+LIGHT_BLUE = "bold lightblue"
+RESET = "/"
+UNDERLINE = "underline"
+BACKGROUND = "#1e1e2e"
+
+[dark]
+GREEN = "green"
+RED = "red"
+ORANGE = "yellow"
+LIGHT_BLUE = "cyan"
+RESET = "/"
+UNDERLINE = "underline"
+BACKGROUND = "#121212"
+
+[high_contrast]
+GREEN = "bold white on green"
+RED = "bold white on red"
+ORANGE = "bold white on yellow"
+LIGHT_BLUE = "bold black on cyan"
+RESET = "/"
+UNDERLINE = "underline"
+BACKGROUND = "#000000"
+
+[catppuccin_mocha]
+GREEN = "#a6e3a1"
+RED = "#f38ba8"
+ORANGE = "#fab387"
+LIGHT_BLUE = "#89dceb"
+RESET = "/"
+UNDERLINE = "underline"
+BACKGROUND = "#1e1e2e"
+
+[catppuccin_macchiato]
+GREEN = "#a6da95"
+RED = "#ed8796"
+ORANGE = "#f5a97f"
+LIGHT_BLUE = "#8aadf4"
+RESET = "/"
+UNDERLINE = "underline"
+BACKGROUND = "#24273a"
+
+[gruvbox_dark]
+GREEN = "#b8bb26"
+RED = "#fb4934"
+ORANGE = "#fe8019"
+LIGHT_BLUE = "#83a598"
+RESET = "/"
+UNDERLINE = "underline"
+BACKGROUND = "#282828"
+
+[onedark]
+GREEN = "#98c379"
+RED = "#e06c75"
+ORANGE = "#d19a66"
+LIGHT_BLUE = "#61afef"
+RESET = "/"
+UNDERLINE = "underline"
+BACKGROUND = "#282c34"
+
+[solarized_dark]
+GREEN = "#859900"
+RED = "#dc322f"
+ORANGE = "#cb4b16"
+LIGHT_BLUE = "#268bd2"
+RESET = "/"
+UNDERLINE = "underline"
+BACKGROUND = "#002b36"
+
+[nord]
+GREEN = "#a3be8c"
+RED = "#bf616a"
+ORANGE = "#d08770"
+LIGHT_BLUE = "#88c0d0"
+RESET = "/"
+UNDERLINE = "underline"
+BACKGROUND = "#2e3440"

--- a/pylings/config/themes.toml
+++ b/pylings/config/themes.toml
@@ -78,3 +78,13 @@ LIGHT_BLUE = "#88c0d0"
 RESET = "/"
 UNDERLINE = "underline"
 BACKGROUND = "#2e3440"
+
+[tender]
+GREEN = "#c9d05c"
+RED = "#f43753"
+ORANGE = "#dc9656"
+LIGHT_BLUE = "#b3deef"
+RESET = "/"
+UNDERLINE = "underline"
+BACKGROUND = "#282828"
+

--- a/pylings/constants.py
+++ b/pylings/constants.py
@@ -1,6 +1,7 @@
 """constants.py: Shared constants for pylings project"""
 
 from pathlib import Path
+import toml
 
 # FILE PATHS
 BASE_DIR = Path.cwd()
@@ -13,13 +14,30 @@ DEBUG_PATH = BASE_DIR / ".pylings_debug.log"
 IGNORED_DIRS = {"__pycache__", ".git"}
 IGNORED_FILES = {".DS_Store", "Thumbs.db"}
 
-# MARKUP STYLES FOR TEXTUAL
-GREEN = "[bold green]"
-LIGHT_BLUE = "[bold lightblue]"
-ORANGE = "[bold orange]"
-RED = "[bold red]"
-RESET_COLOR = "[/]"
-UNDERLINE = "[underline]"
+# THEME CONFIGURATION
+theme_name = "default"
+if PYLINGS_TOML.exists():
+    try:
+        config = toml.load(PYLINGS_TOML)
+        theme_name = config.get("theme", {}).get("name", "default")
+    except Exception:
+        pass
+
+# Load theme definitions
+theme_path = Path(__file__).parent / "config" / "themes.toml"
+themes = toml.load(theme_path)
+selected = themes.get(theme_name, themes["default"])
+
+# TEXTUAL STYLE STRINGS
+GREEN = f"[{selected['GREEN']}]"
+RED = f"[{selected['RED']}]"
+ORANGE = f"[{selected['ORANGE']}]"
+LIGHT_BLUE = f"[{selected['LIGHT_BLUE']}]"
+RESET_COLOR = f"[/{selected['RESET']}]" if selected["RESET"] != "/" else "[/]"
+UNDERLINE = f"[{selected['UNDERLINE']}]"
+
+# BACKGROUND color (used in .styles not markup)
+BACKGROUND_COLOR = selected.get("BACKGROUND", "#1e1e2e")
 
 # FORMATTING CONTROLS
 CLEAR_SCREEN = "\033[2J\033[H"

--- a/pylings/init.py
+++ b/pylings/init.py
@@ -10,6 +10,7 @@ import logging
 from pathlib import Path
 import shutil
 import subprocess
+import textwrap
 import toml
 
 from pylings.constants import IGNORED_DIRS, IGNORED_FILES
@@ -55,8 +56,15 @@ def init_workspace(path: str = None, force: bool = False):
 
     version = PylingsUtils.get_installed_version()
     (target_dir / ".pylings.toml").write_text(
-        f'[workspace]\nversion = "{version}"\nfirsttime=true\n'
-        'current_exercise = "00_intro/intro1.py"'
+        textwrap.dedent(f'''\
+            [workspace]
+            version = "{version}"
+            firsttime = true
+            current_exercise = "00_intro/intro1.py"
+
+            [theme]
+            name = "default"
+        ''')
     )
     initialise_git(target_dir)
     print("Pylings initialised at:", target_dir)

--- a/pylings/styles/ui.tcss
+++ b/pylings/styles/ui.tcss
@@ -1,14 +1,16 @@
+Horizontal {
+    padding-right: 1;
+    padding-left:1;
+}
 Screen {
     background: transparent;
+    align: center middle;
 }
 .hidden {
     display: none;
 }
 ListItem.-highlight {
     background: rgba(100, 100, 100, 0.3);
-}
-Screen {
-    align: center middle;
 }
 #sidebar {
     width: 27%;

--- a/pylings/ui.py
+++ b/pylings/ui.py
@@ -1,8 +1,8 @@
 """Textual-based UI for Pylings.
 
-Provides a terminal-based interactive application for navigating, viewing, 
-and interacting with Python exercises in the Pylings project. This UI is 
-powered by the Textual framework and integrates with the ExerciseManager 
+Provides a terminal-based interactive application for navigating, viewing,
+and interacting with Python exercises in the Pylings project. This UI is
+powered by the Textual framework and integrates with the ExerciseManager
 for backend state and logic.
 """
 import logging
@@ -14,7 +14,8 @@ from textual.widgets import  ListView, ListItem, Static
 
 from pylings.constants import (DONE,DONE_MESSAGE, EXERCISES_DIR,EXERCISE_DONE,
                                EXERCISE_ERROR, EXERCISE_OUTPUT, LIST_VIEW,
-                               LIST_VIEW_NEXT, MAIN_VIEW, MAIN_VIEW_NEXT, PENDING
+                               LIST_VIEW_NEXT, MAIN_VIEW, MAIN_VIEW_NEXT, PENDING,
+                               BACKGROUND_COLOR
 )
 from pylings.exercises import ExerciseManager
 from pylings.utils import PylingsUtils
@@ -25,7 +26,7 @@ class PylingsUI(App):
     """Textual-based UI for Pylings.
 
     Manages the interactive terminal interface, including layout, navigation,
-    exercise display, sidebar list, and user input handling. It integrates with 
+    exercise display, sidebar list, and user input handling. It integrates with
     an ExerciseManager to coordinate updates and actions.
     """
 
@@ -65,6 +66,7 @@ class PylingsUI(App):
     def on_mount(self):
         """Update UI with initial exercise details."""
         log.debug("PylingsUI.on_mount: Entered")
+        self.screen.styles.background = BACKGROUND_COLOR
         self.update_exercise_content()
         sidebar = self.query_one("#sidebar", Vertical)
         main_content = self.query_one("#main", Vertical)
@@ -90,7 +92,7 @@ class PylingsUI(App):
         log.debug("PylingsUI.referesh_exercise_output: Entered")
         if not self.current_exercise:
             log.debug(
-                "PylingsUI.referesh_exercise_output: current_exercise is None (%s)", 
+                "PylingsUI.referesh_exercise_output: current_exercise is None (%s)",
                 self.current_exercise
             )
             return
@@ -174,7 +176,7 @@ class PylingsUI(App):
         )
 
     def update_progress_bar(self):
-        """Generate a Rustlings-style text progress bar inside Static.""" 
+        """Generate a Rustlings-style text progress bar inside Static."""
         log.debug("PylingsUI.update_progress_bar: Entered")
         progress_bar_widget = self.query_one("#progress-bar", Static)
 
@@ -202,7 +204,7 @@ class PylingsUI(App):
         check_progress_widget.update("Checking all exercises")
         if exercise_name:
             log.debug(
-                "PylingsUI.update_update_progress.exercise_name: %s %d/%d", 
+                "PylingsUI.update_update_progress.exercise_name: %s %d/%d",
                 exercise_name, completed, total - 1
             )
             check_progress_widget.update(


### PR DESCRIPTION
### What's Changed

- Replaced hardcoded markup color constants in `pylings/constants.py` with values loaded dynamically from a `themes.toml` file.
- Added a `[theme]` section in `.pylings.toml` to allow storing the theme value (e.g., `"catppuccin_mocha"`).
- Created a new `pylings/config/themes.toml` containing multiple color themes (e.g., `catppuccin_mocha`).
- Updated `pylings/init.py` to write the `[theme]` section when initializing the workspace.
- Modified `pylings/ui.py` to use the themed background color
- Cleaned up duplicated `Screen` styles and added horizontal padding to Horizontal container to improve spacing and layout appearance.

### Screenshots / Preview

- ![image](https://github.com/user-attachments/assets/12689f10-57ea-4f35-8932-56051118588e)
- ![image](https://github.com/user-attachments/assets/ccaef1bd-4b47-42b8-92c5-a832003772ce)
- ![image](https://github.com/user-attachments/assets/db5749ba-b2f0-43ac-bd6a-015c581c036b)
